### PR TITLE
test: strengthen atlas validator failure coverage

### DIFF
--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -35,3 +35,33 @@ def test_unused_cell_must_be_transparent(tmp_path: Path):
     result = validate_atlas(path)
     assert not result["ok"]
     assert any("unused cell idle" in e for e in result["errors"])
+
+
+def test_wrong_dimensions_fail(tmp_path: Path):
+    path = tmp_path / "wrong-size.png"
+    Image.new("RGBA", (64, 64), (0, 0, 0, 0)).save(path)
+
+    result = validate_atlas(path)
+
+    assert not result["ok"]
+    assert any("expected 1536x1872" in error for error in result["errors"])
+
+
+def test_rgb_atlas_requires_alpha_channel(tmp_path: Path):
+    path = tmp_path / "rgb-atlas.png"
+    Image.new("RGB", (ATLAS_WIDTH, ATLAS_HEIGHT), (255, 255, 255)).save(path)
+
+    result = validate_atlas(path)
+
+    assert not result["ok"]
+    assert "atlas does not expose an alpha channel" in result["errors"]
+
+
+def test_unreadable_file_returns_validation_error(tmp_path: Path):
+    path = tmp_path / "not-an-image.txt"
+    path.write_text("not an image", encoding="utf-8")
+
+    result = validate_atlas(path)
+
+    assert not result["ok"]
+    assert any("could not open atlas" in error for error in result["errors"])


### PR DESCRIPTION
## Summary
- cover invalid atlas dimensions
- verify that RGB atlases fail the alpha-channel contract
- verify unreadable inputs return a structured validation error

## Validation
- `pytest -q` — 8 passed
- `ruff check .` — passed

## Notes
This draft changes test coverage only; production validator behavior is unchanged.

> Codex-assisted change, opened with repository owner approval.