### PR TITLE
docs: add privacy-safe demo contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,12 @@ ruff check .
 - Better docs or translations.
 - Cross-platform installation improvements.
 
+## Demo contributions
+
+Public examples must use synthetic, owned, public-domain, or explicitly redistributable material.
+Follow the [privacy-safe demo contribution guide](docs/demo-contributions.md) and include provenance,
+license information, QA evidence, and deterministic validation output.
+
 ## Pull requests
 
 Keep PRs focused. Include:

--- a/docs/demo-contributions.md
+++ b/docs/demo-contributions.md
@@ -1,0 +1,55 @@
+# Privacy-safe demo contributions
+
+Public demos should make PocketMen easy to evaluate without exposing personal reference images or
+shipping assets that contributors cannot redistribute.
+
+## Allowed source material
+
+Use one of the following:
+
+- synthetic references created specifically for the demo;
+- original artwork or photography owned by the contributor;
+- public-domain material; or
+- material with an explicit license that permits redistribution and transformation.
+
+Do not submit private photos, generated pets derived from private photos, local Codex configuration,
+credentials, or protected character assets without documented permission.
+
+## Evidence to include
+
+A reviewable demo should contain:
+
+1. at least two permitted reference views;
+2. a short provenance and license note;
+3. the identity-lock summary and selected style preset;
+4. the canonical base image;
+5. the final contact sheet;
+6. one directional preview and one `running` (working) preview; and
+7. the validator JSON produced without external generation calls in CI.
+
+## Suggested directory layout
+
+```text
+examples/demos/<demo-id>/
+  README.md
+  manifest.json
+  references/
+  canonical-base.png
+  contact-sheet.png
+  previews/
+  validation.json
+```
+
+The demo README should explain the source rights, generation choices, and any limitations. The
+manifest format is intentionally provisional until the schema proposed in Issue #3 is agreed.
+
+## Review checklist
+
+- Every input and output is safe to redistribute.
+- No personal or secret-bearing files are present.
+- The companion identity and motion are understandable from the included evidence.
+- Unused atlas cells are transparent and deterministic validation passes.
+- CI uses only checked-in synthetic fixtures and spends no image-generation credits.
+
+When rights or privacy are unclear, leave the media out of the pull request and ask a maintainer
+before publishing it.

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,9 @@
 
 This repository intentionally does **not** bundle private personal-reference photos or generated pets derived from them.
 
+Read the [privacy-safe demo contribution guide](../docs/demo-contributions.md) before adding public
+example media.
+
 For public demos, use synthetic or explicitly redistributable references. A good demo should show:
 
 1. at least two reference views;


### PR DESCRIPTION
## Summary
- define which source material is safe for public demos
- document required provenance, QA evidence, and a suggested directory layout
- link the guide from the examples and contribution entry points

## Validation
- `pytest -q` — 5 passed
- `ruff check .` — passed

## Tracking
Refs #3. The manifest schema remains intentionally provisional for discussion in that issue.

> Codex-assisted change, opened with repository owner approval.